### PR TITLE
Add a link to web resume

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -132,7 +132,18 @@ const Home = () => (
         <Heading as="h3" variant="section-title">
           🕸 On the web
         </Heading>
-        <List>
+        <Paragraph>
+          Need a formal review of who I am? Check out my{" "}
+          <Link
+            variant={"red-link"}
+            href="https://www.res.manpreetbhatti.com/"
+            isExternal
+          >
+            resume
+          </Link>
+          !
+        </Paragraph>
+        <List mt={2}>
           <ListItem>
             <Link
               href="https://www.linkedin.com/in/manpreet1bhatti/"


### PR DESCRIPTION
Created a link to my web hosted resume. Users will now be able to grab a copy of my resume or review it by scrolling down to the bottom of the home page, refer to the "On the web" section, and click the red resume link.